### PR TITLE
Rename multi-year charts to transition path charts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Multi-Year Charts</title>
+    <title>Transition Path Charts</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/data/locales/en.json
+++ b/src/data/locales/en.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Multi-Year Charts",
+  "app.title": "Transition path charts",
   "app.backToETM": "Back to the ETM",
   "app.sliderSettings": "Slider settings",
   "app.language": "Language",

--- a/src/data/locales/nl.json
+++ b/src/data/locales/nl.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Meerjarengrafieken",
+  "app.title": "Transitiepaden",
   "app.backToETM": "Terug naar het ETM",
   "app.sliderSettings": "Invoervelden",
   "app.language": "Taal",


### PR DESCRIPTION
@ChaelKruip I'm still a little doubtful about the Dutch vs. English title (transitiepaden vs. transition path charts) because it feels somewhat inconsistent. What are your thoughts on this?

Related to https://github.com/quintel/etmodel/pull/3111