### PR TITLE
Interpret and react to received postMessages

### DIFF
--- a/components/ScenarioEditor.tsx
+++ b/components/ScenarioEditor.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useState, useEffect } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 
 import LocaleMessage from './LocaleMessage';
@@ -27,9 +27,30 @@ const urlForInput = (scenarioID: number, inputKey?: string) => {
 };
 
 const ScenarioEditor = (props: ScenarioEditorProps) => {
+  const [performingRequest, setPerformingRequest] = useState<boolean>(false);
+
+  const onPostMessage = (event) => {
+    switch(event.data) {
+      case 'request-started': setPerformingRequest(true); break;
+      case 'request-stopped': setPerformingRequest(false); break;
+    };
+  };
+
+  // Add eventListener only at first component rendercycle
+  useEffect(() => {
+    window.addEventListener('message', onPostMessage);
+
+    // Cleanup eventListener after component unmount
+    return () => { window.removeEventListener('message', onPostMessage); }
+  }, [])
+
+  const onRequestClose = () => {
+    return !performingRequest && props.onClose();
+  }
+
   return (
     <Transition appear show={true} as={Fragment}>
-      <Dialog as="div" open={true} onClose={props.onClose}>
+      <Dialog as="div" open={true} onClose={onRequestClose}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"
@@ -53,29 +74,32 @@ const ScenarioEditor = (props: ScenarioEditorProps) => {
         >
           <div className="fixed inset-0 overflow-y-auto">
             <div className="flex min-h-full items-center justify-center p-4 text-center">
-              <Dialog.Panel className="min-w-[100vw] max-w-[1327px] transform overflow-hidden rounded-md bg-white text-left align-middle shadow-xl transition-all">
+              <Dialog.Panel
+                className="min-w-[100vw] max-w-[1327px] transform overflow-hidden rounded-md bg-white text-left align-middle shadow-xl transition-all"
+              >
                 <Dialog.Title
-                  as="h3"
-                  className="border-b border-gray-300 px-6 py-3 pt-4 text-base font-medium text-gray-900"
+                  className="text-[1.25rem] h-[4.2rem] border-b border-gray-300 px-6 py-3 pt-4 text-base font-medium text-gray-900 align-middle"
                 >
-                  <LocaleMessage
-                    id="scenarioEditor.title"
-                    values={{ year: props.endYear.toString() }}
-                  />
+                  <div className="pt-2 float-left">
+                    <LocaleMessage id="scenarioEditor.title" values={{ year: props.endYear.toString() }} />
+                  </div>
+                  <button
+                    onClick={onRequestClose}
+                    className={
+                      `text-base float-right rounded py-1.5 px-3 text-white transition ${
+                        performingRequest
+                          ? 'bg-gray-500 pointer-events-none'
+                          : 'bg-emerald-600 hover:bg-emerald-700'
+                      }`
+                    }
+                  >
+                    <LocaleMessage id={`scenarioEditor.${performingRequest ? 'pending-request' : 'finish'}`} />
+                  </button>
                 </Dialog.Title>
                 <iframe
                   src={urlForInput(props.scenarioID, props.inputKey)}
                   className="h-[700px] w-full"
                 />
-                {/* iframe here */}
-                <div className="border-t border-gray-300 px-6 py-4">
-                  <button
-                    onClick={props.onClose}
-                    className="rounded bg-emerald-600 py-1.5 px-3 text-white transition hover:bg-emerald-700"
-                  >
-                    <LocaleMessage id="scenarioEditor.finish" />
-                  </button>
-                </div>
               </Dialog.Panel>
             </div>
           </div>

--- a/components/ScenarioEditor.tsx
+++ b/components/ScenarioEditor.tsx
@@ -29,7 +29,7 @@ const urlForInput = (scenarioID: number, inputKey?: string) => {
 const ScenarioEditor = (props: ScenarioEditorProps) => {
   const [performingRequest, setPerformingRequest] = useState<boolean>(false);
 
-  const onPostMessage = (event) => {
+  const onPostMessage = (event: MessageEvent) => {
     switch(event.data) {
       case 'request-started': setPerformingRequest(true); break;
       case 'request-stopped': setPerformingRequest(false); break;

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -14,6 +14,7 @@
 
   "scenarioEditor.title": "Edit {year} scenario",
   "scenarioEditor.finish": "Finish editing",
+  "scenarioEditor.pending-request": "Working...",
 
   "displayAs.title": "Display as",
   "displayAs.area": "Area chart",

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -14,6 +14,7 @@
 
   "scenarioEditor.title": "{year} scenario aanpassen",
   "scenarioEditor.finish": "Gereed",
+  "scenarioEditor.pending-request": "Verwerken...",
 
   "displayAs.title": "Weergeven als",
   "displayAs.area": "Grafiek",


### PR DESCRIPTION
## What?
This PR implements changes which make it possible for the `ScenarioEditor` to disable the 'Finish editing' button while changes made to a scenario are being processed by ETModel. This was suggested as the third possible solution in [this comment](https://github.com/quintel/multi-year-charts/issues/36#issuecomment-1660565860) for the problem described below.

## Why?
As described in issue #36 the ScenarioEditor popup could previously be closed while changes made to a scenario were possibly still being processed by ETModel. Such changes would then not be properly processed and persisted.

## How?
The browser [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API provides a way for different browser documents (`windows`, `iframes`, etc.) to communicate with eachother. PR https://github.com/quintel/etmodel/pull/4140 implements changes that make ETModel emit such messages when changes to a scenario are processed (e.g.: a request to ETEngine is performed). Through changes in this PR the `ScenarioEditor` now listens and acts upon messages received from the `iframe` within it, which runs an instance of the ETModel. Specifically, it disables and enables the 'Finish editing' button when the ETModel instance indicates it is processing a request for scenario changes.

Additionally this PR implements the following changes:
- The 'Finish editing' button is now placed the in top right position of the ScenarioEditor instead of bottom left. This frees up extra vertical space.
- Clicking outside of the ScenarioEditor popup to close it is also no longer possible while a request is being processed.

Closes #36