### PR TITLE
Add interface-group name to slide input_elements

### DIFF
--- a/components/InputsSummary/Row.tsx
+++ b/components/InputsSummary/Row.tsx
@@ -2,7 +2,7 @@ import { ScenarioIndexedInputData } from '../../utils/api/types';
 import sanitizeHtml from 'sanitize-html';
 
 interface RowProps {
-  input: { name: string; key: string; unit: string };
+  input: { name: string; group_name?: string, key: string; unit: string };
   inputData: ScenarioIndexedInputData;
   onInputClick: (id: number, key: string) => void;
   scenarioIDs: number[];
@@ -42,10 +42,16 @@ export default function Row({ input, inputData, onInputClick, scenarioIDs }: Row
     return null;
   }
 
+  let unsanitized_input_name = input.name;
+  unsanitized_input_name += input.group_name ? ` (${input.group_name})` : '';
+
   return (
     <tr key={input.key} className="border-b border-b-gray-300">
-      <td className="p-2 text-left text-gray-600" dangerouslySetInnerHTML={{ __html: sanitizeHtml(input.name, {
-  allowedTags: [ 'sub', 'sup' ]}) }}></td>
+      <td
+        className="p-2 text-left text-gray-600"
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(unsanitized_input_name, { allowedTags: [ 'sub', 'sup' ]}) }}
+      >
+      </td>
       <td key={`input-val-present-${input.key}`} className="px-2 py-2 text-right">
         {formatInputValue(firstInputData.default, input)}
       </td>
@@ -55,18 +61,22 @@ export default function Row({ input, inputData, onInputClick, scenarioIDs }: Row
 
         return (
           <td key={id} className="px-2 text-right">
-            {scenarioInput.user === undefined ? (
-              <span className="text-gray-400">
-                {formatInputValue(scenarioInput.default, input)}
-              </span>
-            ) : (
-              <button
-                onClick={() => onInputClick(id, input.key)}
-                className="-my-1 -mx-2 cursor-pointer rounded py-1 px-2 text-midnight-700 hover:bg-gray-100 hover:text-midnight-900 active:bg-gray-200 active:text-midnight-900"
-              >
-                {formatInputValue(scenarioInput.user, input)}
-              </button>
-            )}
+            {
+              scenarioInput.user === undefined
+                ? (
+                  <span className="text-gray-400">
+                    {formatInputValue(scenarioInput.default, input)}
+                  </span>
+                )
+                : (
+                  <button
+                    onClick={() => onInputClick(id, input.key)}
+                    className="-my-1 -mx-2 cursor-pointer rounded py-1 px-2 text-midnight-700 hover:bg-gray-100 hover:text-midnight-900 active:bg-gray-200 active:text-midnight-900"
+                  >
+                    {formatInputValue(scenarioInput.user, input)}
+                  </button>
+                )
+            }
           </td>
         );
       })}

--- a/components/InputsSummary/Row.tsx
+++ b/components/InputsSummary/Row.tsx
@@ -42,8 +42,12 @@ export default function Row({ input, inputData, onInputClick, scenarioIDs }: Row
     return null;
   }
 
-  let unsanitized_input_name = input.name;
-  unsanitized_input_name += input.group_name ? ` (${input.group_name})` : '';
+  let unsanitized_input_name;
+  if (input.group_name) {
+    unsanitized_input_name = `${input.group_name} - ${input.name}`;
+  } else {
+    unsanitized_input_name = input.name;
+  }
 
   return (
     <tr key={input.key} className="border-b border-b-gray-300">

--- a/components/InputsSummary/Row.tsx
+++ b/components/InputsSummary/Row.tsx
@@ -42,18 +42,18 @@ export default function Row({ input, inputData, onInputClick, scenarioIDs }: Row
     return null;
   }
 
-  let unsanitized_input_name;
+  let unsanitizedInputName
   if (input.group_name) {
-    unsanitized_input_name = `${input.group_name} - ${input.name}`;
+    unsanitizedInputName = `${input.group_name} - ${input.name}`;
   } else {
-    unsanitized_input_name = input.name;
+    unsanitizedInputName = input.name;
   }
 
   return (
     <tr key={input.key} className="border-b border-b-gray-300">
       <td
         className="p-2 text-left text-gray-600"
-        dangerouslySetInnerHTML={{ __html: sanitizeHtml(unsanitized_input_name, { allowedTags: [ 'sub', 'sup' ]}) }}
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(unsanitizedInputName, { allowedTags: [ 'sub', 'sup' ]}) }}
       >
       </td>
       <td key={`input-val-present-${input.key}`} className="px-2 py-2 text-right">

--- a/components/InputsSummary/Section.tsx
+++ b/components/InputsSummary/Section.tsx
@@ -9,7 +9,7 @@ interface SectionProps {
   scenarioIDs: ComponentProps<typeof Row>['scenarioIDs'];
   slide: {
     path: string[];
-    input_elements: { name: string; key: string; unit: string }[];
+    input_elements: { name: string; group_name?: string; key: string; unit: string }[];
   };
 }
 

--- a/components/InputsSummary/Section.tsx
+++ b/components/InputsSummary/Section.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from 'react';
 import Row from './Row';
+import { sortBy } from 'lodash';
 
 import { ScenarioIndexedInputData } from '../../utils/api/types';
 
@@ -46,6 +47,11 @@ export default function Section({ inputData, slide, ...rest }: SectionProps) {
     return null;
   }
 
+  const rows = slide.input_elements.map((element) => (
+    <Row key={element.key} input={element} inputData={inputData} {...rest} />
+  ))
+  const sortedRows = sortBy(rows, 'group_name');
+
   return (
     <>
       <tr className="border-b border-b-gray-300">
@@ -53,9 +59,7 @@ export default function Section({ inputData, slide, ...rest }: SectionProps) {
           {slide.path.join(' → ')}
         </th>
       </tr>
-      {slide.input_elements.map((element) => (
-        <Row key={element.key} input={element} inputData={inputData} {...rest} />
-      ))}
+      {sortedRows}
     </>
   );
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/sanitize-html": "^2.9.0",
     "echarts": "^5.3.3",
     "echarts-for-react": "^3.0.2",
+    "lodash": "^4.17.21",
     "next": "12.2.2",
     "next-auth": "^4.18.7",
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/sanitize-html": "^2.9.0",
     "echarts": "^5.3.3",
     "echarts-for-react": "^3.0.2",
-    "lodash": "^4.17.21",
     "next": "12.2.2",
     "next-auth": "^4.18.7",
     "react": "18.2.0",
@@ -30,6 +29,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
+    "@types/lodash": "^4.14.197",
     "@types/node": "18.0.6",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,6 +3185,11 @@ lodash@^4.17.15:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,6 +870,11 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.197":
+  version "4.14.197"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.197.tgz#e95c5ddcc814ec3e84c891910a01e0c8a378c54b"
+  integrity sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==
+
 "@types/node@*", "@types/node@18.0.6":
   version "18.0.6"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz"
@@ -3183,11 +3188,6 @@ lodash.merge@^4.6.2:
 lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:


### PR DESCRIPTION
## What?
This PR prepends the name of the `interface-group` to the name of the `inputs` that are shown under a `slide` on the 'Slider settings' page (if available) and sorts the inputs by them:
![image](https://github.com/quintel/multi-year-charts/assets/138440410/f1c1b7e0-0fbc-4566-b5fa-a46a7e9da7ab)
_(Situation after changes in this PR: input names with group name prepended)_

## Why?
Multiple unique inputs have the same generic display label such as 'Diesel', 'LPG' or 'Other oil'. When show in a grouped manner such as on the 'Slider settings' page, these inputs were not distinguishable before:
![image](https://github.com/quintel/multi-year-charts/assets/138440410/6e01a042-d775-43b1-9c35-bdd2119e7bb9)
_(Situation before this PR: input names without group names, indistinguishable)_

For a more detailed description of the issue see #39.

## How?
PR https://github.com/quintel/etmodel/pull/4141 added the `group_name` to individual inputs belonging to a slide through the `SlidePresenter`. The 'Slider settings' page makes use of output of the `SlidePresenter` to display the slides and their inputs. This PR simply prepends the `group_name` to the name of each input and then sorts the inputs in each slide by this group_name.

Closes #39