### PR TITLE
Changed default graph type to bar chart

### DIFF
--- a/store/reducers.ts
+++ b/store/reducers.ts
@@ -7,7 +7,7 @@ const initialState: AppState = {
   scenarioData: {},
   scenarios: [],
   queries: {},
-  preferredChartStyle: 'area' as ChartStyle,
+  preferredChartStyle: 'bar' as ChartStyle,
 };
 
 /**


### PR DESCRIPTION
A simple change to adjust the default chart type. I tried to find a way to identify transition paths separately from collections so they could have different defaults as per issue #46 but couldn't find a way to actually identify the difference between the groups. Maybe you have a hot tip @noracato ?

Closes: #46 (but a more comprehensive solution would include different default chart types).