### PR TITLE
CTM-ETM coupling 5b deliverable 2 & 3

### DIFF
--- a/data/charts/finalDemand.ts
+++ b/data/charts/finalDemand.ts
@@ -25,12 +25,14 @@ export default {
         'myc_final_demand_of_green_gas',
         'myc_final_demand_of_hydrogen',
         'myc_final_demand_of_liquid_biofuels',
+        'myc_final_demand_of_methanol',
         'myc_final_demand_of_natural_gas_and_derivatives',
         'myc_final_demand_of_oil_and_derivatives',
         'myc_final_demand_of_renewable_electricity',
         'myc_final_demand_of_renewable_heat',
         'myc_final_demand_of_solar_thermal',
-        'myc_final_demand_of_solid_biofuels'
+        'myc_final_demand_of_solid_biofuels',
+        'myc_final_demand_of_waste_mix'
       ]
     },
     {
@@ -87,6 +89,13 @@ export default {
         'myc_final_demand_of_liquid_biofuels_in_households',
         'myc_final_demand_of_liquid_biofuels_in_industry',
         'myc_final_demand_of_liquid_biofuels_in_transport',
+        'myc_final_demand_of_methanol_in_agriculture',
+        'myc_final_demand_of_methanol_in_buildings',
+        'myc_final_demand_of_methanol_in_bunkers',
+        'myc_final_demand_of_methanol_in_energy_and_other',
+        'myc_final_demand_of_methanol_in_households',
+        'myc_final_demand_of_methanol_in_industry',
+        'myc_final_demand_of_methanol_in_transport',
         'myc_final_demand_of_natural_gas_and_derivatives_in_agriculture',
         'myc_final_demand_of_natural_gas_and_derivatives_in_buildings',
         'myc_final_demand_of_natural_gas_and_derivatives_in_bunkers',
@@ -128,7 +137,14 @@ export default {
         'myc_final_demand_of_solid_biofuels_in_energy_and_other',
         'myc_final_demand_of_solid_biofuels_in_households',
         'myc_final_demand_of_solid_biofuels_in_industry',
-        'myc_final_demand_of_solid_biofuels_in_transport'
+        'myc_final_demand_of_solid_biofuels_in_transport',
+        'myc_final_demand_of_waste_mix_in_agriculture',
+        'myc_final_demand_of_waste_mix_in_buildings',
+        'myc_final_demand_of_waste_mix_in_bunkers',
+        'myc_final_demand_of_waste_mix_in_energy_and_other',
+        'myc_final_demand_of_waste_mix_in_households',
+        'myc_final_demand_of_waste_mix_in_industry',
+        'myc_final_demand_of_waste_mix_in_transport',
       ]
     },
     {
@@ -143,12 +159,14 @@ export default {
         'myc_final_demand_of_green_gas_in_agriculture',
         'myc_final_demand_of_hydrogen_in_agriculture',
         'myc_final_demand_of_liquid_biofuels_in_agriculture',
+        'myc_final_demand_of_methanol_in_agriculture',
         'myc_final_demand_of_natural_gas_and_derivatives_in_agriculture',
         'myc_final_demand_of_oil_and_derivatives_in_agriculture',
         'myc_final_demand_of_renewable_electricity_in_agriculture',
         'myc_final_demand_of_renewable_heat_in_agriculture',
         'myc_final_demand_of_solar_thermal_in_agriculture',
-        'myc_final_demand_of_solid_biofuels_in_agriculture'
+        'myc_final_demand_of_solid_biofuels_in_agriculture',
+        'myc_final_demand_of_waste_mix_in_agriculture'
       ]
     },
     {
@@ -163,12 +181,14 @@ export default {
         'myc_final_demand_of_green_gas_in_buildings',
         'myc_final_demand_of_hydrogen_in_buildings',
         'myc_final_demand_of_liquid_biofuels_in_buildings',
+        'myc_final_demand_of_methanol_in_buildings',
         'myc_final_demand_of_natural_gas_and_derivatives_in_buildings',
         'myc_final_demand_of_oil_and_derivatives_in_buildings',
         'myc_final_demand_of_renewable_electricity_in_buildings',
         'myc_final_demand_of_renewable_heat_in_buildings',
         'myc_final_demand_of_solar_thermal_in_buildings',
-        'myc_final_demand_of_solid_biofuels_in_buildings'
+        'myc_final_demand_of_solid_biofuels_in_buildings',
+        'myc_final_demand_of_waste_mix_in_buildings'
       ]
     },
     {
@@ -183,12 +203,14 @@ export default {
         'myc_final_demand_of_green_gas_in_bunkers',
         'myc_final_demand_of_hydrogen_in_bunkers',
         'myc_final_demand_of_liquid_biofuels_in_bunkers',
+        'myc_final_demand_of_methanol_in_bunkers',
         'myc_final_demand_of_natural_gas_and_derivatives_in_bunkers',
         'myc_final_demand_of_oil_and_derivatives_in_bunkers',
         'myc_final_demand_of_renewable_electricity_in_bunkers',
         'myc_final_demand_of_renewable_heat_in_bunkers',
         'myc_final_demand_of_solar_thermal_in_bunkers',
-        'myc_final_demand_of_solid_biofuels_in_bunkers'
+        'myc_final_demand_of_solid_biofuels_in_bunkers',
+        'myc_final_demand_of_waste_mix_in_bunkers'
       ]
     },
     {
@@ -203,12 +225,14 @@ export default {
         'myc_final_demand_of_green_gas_in_energy_and_other',
         'myc_final_demand_of_hydrogen_in_energy_and_other',
         'myc_final_demand_of_liquid_biofuels_in_energy_and_other',
+        'myc_final_demand_of_methanol_in_energy_and_other',
         'myc_final_demand_of_natural_gas_and_derivatives_in_energy_and_other',
         'myc_final_demand_of_oil_and_derivatives_in_energy_and_other',
         'myc_final_demand_of_renewable_electricity_in_energy_and_other',
         'myc_final_demand_of_renewable_heat_in_energy_and_other',
         'myc_final_demand_of_solar_thermal_in_energy_and_other',
-        'myc_final_demand_of_solid_biofuels_in_energy_and_other'
+        'myc_final_demand_of_solid_biofuels_in_energy_and_other',
+        'myc_final_demand_of_waste_mix_in_energy_and_other'
       ]
     },
     {
@@ -223,12 +247,14 @@ export default {
         'myc_final_demand_of_green_gas_in_households',
         'myc_final_demand_of_hydrogen_in_households',
         'myc_final_demand_of_liquid_biofuels_in_households',
+        'myc_final_demand_of_methanol_in_households',
         'myc_final_demand_of_natural_gas_and_derivatives_in_households',
         'myc_final_demand_of_oil_and_derivatives_in_households',
         'myc_final_demand_of_renewable_electricity_in_households',
         'myc_final_demand_of_renewable_heat_in_households',
         'myc_final_demand_of_solar_thermal_in_households',
-        'myc_final_demand_of_solid_biofuels_in_households'
+        'myc_final_demand_of_solid_biofuels_in_households',
+        'myc_final_demand_of_waste_mix_in_households'
       ]
     },
     {
@@ -243,12 +269,14 @@ export default {
         'myc_final_demand_of_green_gas_in_industry',
         'myc_final_demand_of_hydrogen_in_industry',
         'myc_final_demand_of_liquid_biofuels_in_industry',
+        'myc_final_demand_of_methanol_in_industry',
         'myc_final_demand_of_natural_gas_and_derivatives_in_industry',
         'myc_final_demand_of_oil_and_derivatives_in_industry',
         'myc_final_demand_of_renewable_electricity_in_industry',
         'myc_final_demand_of_renewable_heat_in_industry',
         'myc_final_demand_of_solar_thermal_in_industry',
-        'myc_final_demand_of_solid_biofuels_in_industry'
+        'myc_final_demand_of_solid_biofuels_in_industry',
+        'myc_final_demand_of_waste_mix_in_industry'
       ]
     },
     {
@@ -263,12 +291,14 @@ export default {
         'myc_final_demand_of_green_gas_in_transport',
         'myc_final_demand_of_hydrogen_in_transport',
         'myc_final_demand_of_liquid_biofuels_in_transport',
+        'myc_final_demand_of_methanol_in_transport',
         'myc_final_demand_of_natural_gas_and_derivatives_in_transport',
         'myc_final_demand_of_oil_and_derivatives_in_transport',
         'myc_final_demand_of_renewable_electricity_in_transport',
         'myc_final_demand_of_renewable_heat_in_transport',
         'myc_final_demand_of_solar_thermal_in_transport',
-        'myc_final_demand_of_solid_biofuels_in_transport'
+        'myc_final_demand_of_solid_biofuels_in_transport',
+        'myc_final_demand_of_waste_mix_in_transport'
       ]
     }
   ]

--- a/data/charts/renewables.ts
+++ b/data/charts/renewables.ts
@@ -14,7 +14,8 @@ export default {
         'myc_final_demand_of_renewable_heat_from_geothermal_and_ambient',
         'myc_final_demand_of_renewable_hydrogen',
         'myc_final_demand_of_renewable_liquid_biofuels',
-        'myc_final_demand_of_renewable_solid_biofuels'
+        'myc_final_demand_of_renewable_solid_biofuels',
+        'myc_final_demand_of_renewable_waste'
       ]
     }
   ]

--- a/data/charts/renewables.ts
+++ b/data/charts/renewables.ts
@@ -6,6 +6,7 @@ export default {
       key: 'by_carrier',
       slug: 'by-carrier',
       series: [
+        'myc_final_demand_of_renewable_waste',
         'myc_final_demand_of_renewable_electricity_from_other',
         'myc_final_demand_of_renewable_electricity_from_solar',
         'myc_final_demand_of_renewable_electricity_from_wind',
@@ -14,8 +15,8 @@ export default {
         'myc_final_demand_of_renewable_heat_from_geothermal_and_ambient',
         'myc_final_demand_of_renewable_hydrogen',
         'myc_final_demand_of_renewable_liquid_biofuels',
-        'myc_final_demand_of_renewable_solid_biofuels',
-        'myc_final_demand_of_renewable_waste'
+        'myc_final_demand_of_renewable_methanol',
+        'myc_final_demand_of_renewable_solid_biofuels'
       ]
     }
   ]

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -77,6 +77,8 @@
   "series.solar_thermal": "Solar thermal",
   "series.solid_biofuels": "Solid biofuels",
   "series.ammonia": "Ammonia",
+  "series.methanol": "Methanol",
+  "series.waste_mix": "Waste mix",
 
   "series.myc_final_demand_of_renewable_electricity_from_other": "Electricity from other renewable sources",
   "series.myc_final_demand_of_renewable_electricity_from_solar": "Electricity from solar PV",
@@ -86,5 +88,6 @@
   "series.myc_final_demand_of_renewable_heat_from_geothermal_and_ambient": "Heat from geothermal and ambient sources",
   "series.myc_final_demand_of_renewable_hydrogen": "Renewable hydrogen",
   "series.myc_final_demand_of_renewable_liquid_biofuels": "Renewable liquid biofuels",
-  "series.myc_final_demand_of_renewable_solid_biofuels": "Renewable solid biofuels"
+  "series.myc_final_demand_of_renewable_solid_biofuels": "Renewable solid biofuels",
+  "series.myc_final_demand_of_renewable_waste": "Biogenic waste"
 }

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -89,5 +89,6 @@
   "series.myc_final_demand_of_renewable_hydrogen": "Renewable hydrogen",
   "series.myc_final_demand_of_renewable_liquid_biofuels": "Renewable liquid biofuels",
   "series.myc_final_demand_of_renewable_solid_biofuels": "Renewable solid biofuels",
-  "series.myc_final_demand_of_renewable_waste": "Biogenic waste"
+  "series.myc_final_demand_of_renewable_methanol": "Renewable methanol",
+  "series.myc_final_demand_of_renewable_waste": "Biogenic waste"  
 }

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -77,6 +77,8 @@
   "series.solar_thermal": "Zonthermie",
   "series.solid_biofuels": "Vaste biobrandstoffen",
   "series.ammonia": "Ammoniak",
+  "series.methanol": "Methanol",
+  "series.waste_mix": "Afvalmix",
 
   "series.myc_final_demand_of_renewable_electricity_from_other": "Elektriciteit uit overige hernieuwbare bronnen",
   "series.myc_final_demand_of_renewable_electricity_from_solar": "Elektriciteit uit zon",
@@ -86,5 +88,6 @@
   "series.myc_final_demand_of_renewable_heat_from_geothermal_and_ambient": "Warmte uit geothermie en omgevingswarmte",
   "series.myc_final_demand_of_renewable_hydrogen": "Hernieuwbare waterstof",
   "series.myc_final_demand_of_renewable_liquid_biofuels": "Vloeibare biobrandstoffen",
-  "series.myc_final_demand_of_renewable_solid_biofuels": "Vaste biobrandstoffen"
+  "series.myc_final_demand_of_renewable_solid_biofuels": "Vaste biobrandstoffen",
+  "series.myc_final_demand_of_renewable_waste": "Biogeen afval"
 }

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -89,5 +89,6 @@
   "series.myc_final_demand_of_renewable_hydrogen": "Hernieuwbare waterstof",
   "series.myc_final_demand_of_renewable_liquid_biofuels": "Vloeibare biobrandstoffen",
   "series.myc_final_demand_of_renewable_solid_biofuels": "Vaste biobrandstoffen",
-  "series.myc_final_demand_of_renewable_waste": "Biogeen afval"
+  "series.myc_final_demand_of_renewable_methanol": "Hernieuwbare methanol",
+  "series.myc_final_demand_of_renewable_waste": "Biogeen afval"  
 }


### PR DESCRIPTION
This PR contains updates of user output for deliverable 2&3 of the CTM-ETM coupling projects. The focus is to update outputs considering changes in modelling of:

- methanol
- waste mix
- oil mix
- ammonia

The (queries for the) following elements are updated:

- Data-exports
- Charts
- Dashboard items
- MYC

Goes with:
- https://github.com/quintel/etsource/pull/3093
- https://github.com/quintel/etmodel/pull/4302
- https://github.com/quintel/multi-year-charts/pull/49