### PR TITLE
Updated serialization and parsing of url and fixed minor bugs

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -155,7 +155,7 @@ const Chart = ({ series, style }: ChartProps) => {
     },
     grid: {
       top: '5%',
-      left: '0%',
+      left: '3%',
       right: '2%',
       bottom: '0%',
       containLabel: true,

--- a/components/ChartTable.tsx
+++ b/components/ChartTable.tsx
@@ -92,8 +92,8 @@ const ChartTable: FC<Omit<ChartProps, 'style' | 'type'> & { colorSeries?: boolea
       <thead>
         <tr className="sticky top-0 border-b-2 border-gray-300 bg-white">
           <th className="px-3 text-left fixed-width-cell"></th>
-          {series.categories.map((year) => (
-            <th key={`year-${year}`} className="p-3 text-right fixed-width-cell">
+          {series.categories.map((year, index) => (
+            <th key={`year-${index}`} className="p-3 text-right fixed-width-cell">
               {year}
             </th>
           ))}

--- a/components/ChartWrapper/UnitToggle.tsx
+++ b/components/ChartWrapper/UnitToggle.tsx
@@ -20,7 +20,7 @@ function UnitToggle({ currentChart }: { currentChart: string }) {
   const [value, setValue] = useState<'J' | 'Wh'>('J');
 
   // Charts that should grey out the toggle
-  const greyedOutCharts = ['co2_emissions', 'installed_production_capacity', 'flexibl_capacity'];
+  const greyedOutCharts = ['co2_emissions', 'installed_production_capacity', 'flexible_capacity'];
   const isGreyedOut = greyedOutCharts.includes(currentChart);
 
   useEffect(() => {

--- a/components/InputsSummary/InputsTable.tsx
+++ b/components/InputsSummary/InputsTable.tsx
@@ -3,7 +3,7 @@ import Section from './Section';
 import { ScenarioIndexedInputData, ScenarioIndexedScenarioData } from '../../utils/api/types';
 import sortScenarios from '../../utils/sortScenarios';
 import useTranslate from '../../utils/useTranslate';
-import { serializeTableState, parseTableState } from '../../utils/tableState';
+import { serializeTableState, parseTableState} from '../../utils/tableState';
 
 interface InputsTableProps {
   inputs: ScenarioIndexedInputData;
@@ -28,7 +28,7 @@ const InputsTable: React.FC<InputsTableProps> = ({ inputs, scenarios, inputList,
 
   // Update the URL with the current state for deep linking
   const updateUrlWithState = () => {
-    const stateString = serializeTableState(expandedSections, inputList);
+    const stateString = serializeTableState(expandedSections, expandedSubCategories, expandedMainCategories, filteredGroupedInputList, showAllInputs);
     const newUrl = `${window.location.pathname}?state=${stateString}`;
     window.history.replaceState(null, '', newUrl);
   };
@@ -40,17 +40,18 @@ const InputsTable: React.FC<InputsTableProps> = ({ inputs, scenarios, inputList,
     } else {
       setHasMounted(true);
     }
-  }, [expandedSections]);
+  }, [expandedMainCategories, expandedSubCategories, expandedSections, showAllInputs]);
 
   // Effect to restore state from URL on component mount
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const stateString = params.get('state');
+    const url = window.location.href;
+    const stateString = url.split('?state=')[1] || '';
     if (stateString) {
-      const { expandedMainCategories, expandedSubCategories, expandedSections } = parseTableState(stateString, inputList);
+      const { expandedMainCategories, expandedSubCategories, expandedSections, showAllInputs } = parseTableState(stateString, filteredGroupedInputList);
       setExpandedMainCategories(expandedMainCategories);
       setExpandedSubCategories(expandedSubCategories);
       setExpandedSections(expandedSections);
+      setShowAllInputs(showAllInputs);
     }
   }, [inputList]);
 
@@ -181,7 +182,7 @@ const InputsTable: React.FC<InputsTableProps> = ({ inputs, scenarios, inputList,
               {sortedScenarios[0].scenario.startYear}
             </th>
             {sortedScenarios.map(({ scenario: { id, endYear } }) => (
-              <th key={`year-${endYear} `} className="w-[12%] p-2 text-right">
+              <th key={`year-${endYear}-${id}`} className="w-[12%] p-2 text-right">
                 <button
                   onClick={() => openModal(id)}
                   className="-my-1 -mx-2 cursor-pointer rounded py-1 px-2 text-midnight-700 hover:bg-gray-100 hover:text-midnight-900 active:bg-gray-200 active:text-midnight-900"


### PR DESCRIPTION
Now the url is more readable and will remain stable over time unless there are major changes to the slider hierarchy. By only specifying the highest level for which all children are expanded, the url remains simplified in most cases.

#### How it works:
There are three levels of hierarchy (A,B,C). If all children of a member of level A are present, only A will be appended to the url. Likewise for level B, except it will be appended as A/B. Multiple sections in different parts can be appended to the same url, e.g. A/B1,A/B2.

This PR also updates the y-axis marginally and resolves some duplicate key errors.

Closes #69 