### PR TITLE
Adding bunkers to multi-year-charts

### DIFF
--- a/data/charts/finalDemand.ts
+++ b/data/charts/finalDemand.ts
@@ -11,7 +11,8 @@ export default {
         'myc_final_demand_in_households',
         'myc_final_demand_in_industry',
         'myc_final_demand_in_other_and_energy_sector',
-        'myc_final_demand_in_transport'
+        'myc_final_demand_in_transport',
+        'myc_final_demand_in_bunkers'
       ]
     },
     {


### PR DESCRIPTION
This PR adds Hydrogen and electricity in international transport.

For this repository, international transport was missing in the final demand by sector chart. 
This was added.


Goes together with:
PR [ETsource](https://github.com/quintel/etsource/pull/3133)
PR [ETModel](https://github.com/quintel/etmodel/pull/4355)