### PR TITLE
Reverting back to old auth setup for collections

### DIFF
--- a/components/SessionInformation.tsx
+++ b/components/SessionInformation.tsx
@@ -40,7 +40,7 @@ const SessionInformation = () => {
       <Menu.Item
         as="a"
         target="_blank"
-        href={`${process.env.NEXT_PUBLIC_ETENGINE_URL}/identity/profile`}
+        href={`${process.env.NEXT_PUBLIC_MYETM_URL}/identity/profile`}
         className="group"
       >
         <IdentificationIcon className="mr-2 h-5 w-5 opacity-75 group-hover:opacity-100" />
@@ -48,7 +48,7 @@ const SessionInformation = () => {
       </Menu.Item>
       <Menu.Item
         onClick={() =>
-          signOut({ callbackUrl: `${process.env.NEXT_PUBLIC_ETENGINE_URL}/identity/sign_out` })
+          signOut({ callbackUrl: `${process.env.NEXT_PUBLIC_MYETM_URL}/identity/sign_out` })
         }
       >
         <LogoutIcon className="mr-2 h-5 w-5 opacity-75 group-hover:opacity-100" />

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,101 +1,45 @@
 import NextAuth from 'next-auth';
 
 /**
- * Fetches the token for communicating with ETEngine from MyETM.
- */
-async function fetchEngineToken(userId) {
-  const url = `${process.env.NEXT_PUBLIC_MYETM_URL}/identity/access_tokens`;
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'client_credentials',
-      client_id: process.env.ETENGINE_CLIENT_ID,
-      user_id: userId,
-    }),
-  });
-  if (!response.ok) {
-    console.error(`Failed to fetch ETEngine token. Status: ${response.status}`); // Log failure status
-    throw new Error('Failed to get ETEngine token');
-  }
-  return response.json();
-}
-
-/**
- * Takes a token, and returns a new token with updated `accessToken` and `accessTokenExpires`. If an
- * error occurs, returns the old token and an error property
- */
-async function refreshEngineAccessToken(token) {
-  try {
-    const url = `${process.env.NEXT_PUBLIC_MYETM_URL}/identity/access_tokens`;
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'client_credentials',
-        client_id: process.env.ETENGINE_CLIENT_ID,
-        user_id: token.userId,
-      }),
-    });
-    const refreshedTokens = await response.json();
-
-    if (!response.ok || !refreshedTokens.access_token) {
-      throw refreshedTokens;
-    }
-
-    return {
-      ...token,
-      etAccessToken: refreshedTokens.access_token,
-      etAccessTokenExpires: Date.now() + ((refreshedTokens.expires_in || 3600) * 1000),
-    };
-  } catch (error) {
-    console.error('Error refreshing ETEngine access token:', error);
-    return {
-      ...token,
-      error: 'RefreshEngineAccessTokenError',
-    };
-  }
-}
-
-/**
  * Takes a token, and returns a new token with updated `accessToken` and `accessTokenExpires`. If an
  * error occurs, returns the old token and an error property
  */
 async function refreshAccessToken(token) {
   try {
-    const url = `${process.env.NEXT_PUBLIC_MYETM_URL}/identity/access_tokens`;
+    const url =
+      `${process.env.NEXT_PUBLIC_MYETM_URL}/oauth/authorize?` +
+      new URLSearchParams({
+        client_id: process.env.AUTH_CLIENT_ID,
+        client_secret: process.env.AUTH_CLIENT_SECRET,
+        grant_type: 'refresh_token',
+        refresh_token: token.refreshToken,
+      });
 
     const response = await fetch(url, {
-      method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        "Content-Type": "application/x-www-form-urlencoded",
       },
-      body: new URLSearchParams({
-        grant_type: 'client_credentials',
-        client_id: process.env.AUTH_CLIENT_ID,
-        user_id: token.userId,
-      }),
+      method: "POST",
     });
 
     const refreshedTokens = await response.json();
 
-    if (!response.ok || !refreshedTokens.access_token) {
-      throw refreshedTokens;
+    if (!response.ok) {
+      throw new Error(refreshedTokens.error_description || "Failed to refresh token");
     }
 
     return {
-      ...token, // Keep the existing token data
+      ...token,
       accessToken: refreshedTokens.access_token,
-      accessTokenExpires: Date.now() + (refreshedTokens.expires_in * 1000 || 3600 * 1000), // Default to 1 hour if expires_in is missing
+      accessTokenExpires: Date.now() + refreshedTokens.expires_in * 1000, // Convert to timestamp
+      refreshToken: refreshedTokens.refresh_token ?? token.refreshToken,
     };
   } catch (error) {
-    console.error('Error refreshing access token:', error);
+    console.error("Error refreshing access token:", error);
+
     return {
       ...token,
-      error: 'RefreshAccessTokenError',
+      error: "RefreshAccessTokenError",
     };
   }
 }
@@ -110,6 +54,7 @@ export const authOptions = {
       wellKnown: `${process.env.NEXT_PUBLIC_MYETM_URL}/.well-known/openid-configuration`,
       authorization: {
         params: { scope: 'openid profile email scenarios:read scenarios:write' },
+        prompt: 'consent'
       },
 
       idToken: true,
@@ -127,51 +72,31 @@ export const authOptions = {
     },
   ],
   callbacks: {
-    jwt: async ({ token, user, account }) => {
-      // On initial sign in
+    jwt: ({ token, user, account }) => {
       if (account && user) {
-
-        let newToken = {
-          ...token,
-          idAccessToken: account.access_token,
-          idAccessTokenExpires: account.expires_at ? account.expires_at * 1000 : null,
-          idRefreshToken: account.refresh_token,
+        return {
+          accessToken: account.access_token,
+          accessTokenExpires: account.expires_at ? account.expires_at * 1000 : null,
+          refreshToken: account.refresh_token,
           user,
-          userId: user.id,
         };
-
-        // Refresh ID token if expired
-        if (newToken.idAccessTokenExpires && Date.now() > newToken.idAccessTokenExpires) {
-          console.log('Refreshing ID token...');
-          newToken = await refreshAccessToken(newToken);
-        }
-
-        // Fetch new ETEngine token
-        try {
-          const engineTokens = await fetchEngineToken(newToken.userId);
-          newToken.etAccessToken = engineTokens.access_token;
-          newToken.etAccessTokenExpires = Date.now() + ((engineTokens.expires_in || 3600) * 1000);
-        } catch (error) {
-          console.error('Error fetching ETEngine tokens:', error);
-        }
-
-        return newToken;
       }
 
-      // Refresh ETEngine token if expired or about to expire
-      if (!token.etAccessTokenExpires || Date.now() > token.etAccessTokenExpires - 60 * 1000) {
-        token = await refreshEngineAccessToken(token);
+      // Return previous token if the access token has not expired yet
+      if (!token.accessTokenExpires || Date.now() < token.accessTokenExpires) {
+        return token;
       }
 
-      return token;
+      // Access token has expired, try to update it
+      return refreshAccessToken(token);
     },
     session({ session, token }) {
-
       const newSession = { ...session };
+
       newSession.user = token.user;
-      newSession.idAccessToken = token.idAccessToken;
-      newSession.etAccessToken = token.etAccessToken;
+      newSession.accessToken = token.accessToken;
       newSession.error = token.error;
+
       return newSession;
     },
     async redirect({ url, baseUrl }) {
@@ -181,7 +106,7 @@ export const authOptions = {
       } else if (new URL(url).origin === baseUrl) {
         // Allows callback URLs on the same origin
         return Promise.resolve(url);
-      } else if (new URL(url).origin === process.env.NEXTAUTH_URL) {
+      } else if (new URL(url).origin === process.env.NEXT_PUBLIC_MYETM_URL) {
         // Allow redirects to ETEngine.
         return Promise.resolve(url);
       }

--- a/pages/api/scenarios/[id]/index.tsx
+++ b/pages/api/scenarios/[id]/index.tsx
@@ -9,7 +9,7 @@ const ScenarioProxy = async function (req: NextApiRequest, res: NextApiResponse)
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: token?.etAccessToken ? `Bearer ${token.etAccessToken}` : '',
+      Authorization: token ? `Bearer ${token["accessToken"]}` : '',
     },
     method: req.method,
     body: JSON.stringify(req.body),


### PR DESCRIPTION
Just reverted back to the previous setup without requesting ETAccessTokens. This implementation seems to work, with the exception that before the application is authorized as an OAuthApp (before first login) it still sometimes throws an error and gets you to login again, which means you have to restart your workflow. After the original login the session is set up properly and it works well - but it would obviously be nice to fix that glitch in the long run.

Goes with [this PR](https://github.com/quintel/my-etm/pull/77) on MyETM.
