### PR TITLE
Fix links for select a scenario and back to the ETM

### DIFF
--- a/components/MainNav.tsx
+++ b/components/MainNav.tsx
@@ -34,7 +34,7 @@ const MainNav = () => {
         <LocaleSwitcher currentLocale={currentLocale} setLocale={setLocale} />
         <a
           className="inline-flex items-center rounded bg-emerald-600 bg-gradient-to-b from-white/20 to-transparent px-3 py-1 pl-1.5 text-xs font-medium text-white shadow transition hover:bg-emerald-500 active:bg-emerald-600 active:shadow-inner"
-          href={process.env.NEXT_PUBLIC_ETMODEL_URL}
+          href={`${process.env.NEXT_PUBLIC_MYETM_URL}/collections`}
         >
           <ArrowSmLeftIcon className="mr-1 h-5 w-5" />
           <LocaleMessage id="app.backToETM" />

--- a/components/MainNav.tsx
+++ b/components/MainNav.tsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import { useSession } from 'next-auth/react';
 
 import { PresentationChartLineIcon } from '@heroicons/react/outline';
 import { ArrowSmLeftIcon } from '@heroicons/react/solid';
@@ -10,6 +11,12 @@ import SessionInformation from './SessionInformation';
 
 const MainNav = () => {
   const { currentLocale, setLocale } = useContext(LocaleContext);
+  const { data: session } = useSession();
+
+  // Determine the URL based on session
+  const etmUrl = session
+  ? `${process.env.NEXT_PUBLIC_MYETM_URL}/collections`  // Authenticated
+  : `${process.env.NEXT_PUBLIC_ETMODEL_URL}`;           // Default
 
   return (
     <nav
@@ -34,7 +41,7 @@ const MainNav = () => {
         <LocaleSwitcher currentLocale={currentLocale} setLocale={setLocale} />
         <a
           className="inline-flex items-center rounded bg-emerald-600 bg-gradient-to-b from-white/20 to-transparent px-3 py-1 pl-1.5 text-xs font-medium text-white shadow transition hover:bg-emerald-500 active:bg-emerald-600 active:shadow-inner"
-          href={`${process.env.NEXT_PUBLIC_MYETM_URL}/collections`}
+          href={etmUrl}
         >
           <ArrowSmLeftIcon className="mr-1 h-5 w-5" />
           <LocaleMessage id="app.backToETM" />

--- a/components/MissingScenarios.tsx
+++ b/components/MissingScenarios.tsx
@@ -14,6 +14,15 @@ const MissingScenarios = () => {
     if (loader) { loader.remove(); }
   }, 3000)
 
+  setTimeout(() => {
+    const loader = document.getElementById('overlay-wait');
+    if (loader) { loader.remove(); }
+  }, 3000)
+  // Determine the URL based on session
+  const etmUrl = session
+    ? `${process.env.NEXT_PUBLIC_MYETM_URL}/collections`  // Authenticated
+    : `${process.env.NEXT_PUBLIC_ETMODEL_URL}`;           // Default
+
   return (
     <div>
       <Head>
@@ -48,7 +57,7 @@ const MissingScenarios = () => {
           )}
           <div className="mt-8 flex justify-center gap-4">
             <a
-              href={`${process.env.NEXT_PUBLIC_MYETM_URL}/collections`}
+              href={etmUrl}
               className="rounded-md bg-midnight-500 px-3.5 py-2 font-medium text-white transition hover:bg-midnight-600 active:bg-midnight-700"
             >
               ← <LocaleMessage id="app.backToETM" />

--- a/components/MissingScenarios.tsx
+++ b/components/MissingScenarios.tsx
@@ -48,7 +48,7 @@ const MissingScenarios = () => {
           )}
           <div className="mt-8 flex justify-center gap-4">
             <a
-              href={`${process.env.NEXT_PUBLIC_ETMODEL_URL}`}
+              href={`${process.env.NEXT_PUBLIC_MYETM_URL}/collections`}
               className="rounded-md bg-midnight-500 px-3.5 py-2 font-medium text-white transition hover:bg-midnight-600 active:bg-midnight-700"
             >
               ← <LocaleMessage id="app.backToETM" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,7 @@ const Home: NextPage = () => {
       </p>
       <p className="mt-4">
         <a
-          href={`${process.env.NEXT_PUBLIC_ETMODEL_URL}`}
+          href={`${process.env.NEXT_PUBLIC_MYETM_URL}/collections`}
           className="-m-3 p-3 font-medium text-emerald-600 hover:text-emerald-800"
         >
           <LocaleMessage id="index.selectScenario" /> →

--- a/utils/api/middleware.ts
+++ b/utils/api/middleware.ts
@@ -43,9 +43,9 @@ const fetchInputs = (conn: Connection, dispatch: Dispatch<AnyAction>) => {
  * passed into Redux via the UPDATE_API_DATA action.
  */
 const createAPIMiddleware = () => {
-  if (!process.env.NEXT_PUBLIC_MYETM_URL) {
+  if (!process.env.NEXT_PUBLIC_ETENGINE_URL) {
     throw new Error(
-      'Cannot create API middleware without an API URL. Please set NEXT_PUBLIC_MYETM_URL.'
+      'Cannot create API middleware without an API URL. Please set NEXT_PUBLIC_ETENGINE_URL.'
     );
   }
 

--- a/utils/api/middleware.ts
+++ b/utils/api/middleware.ts
@@ -43,9 +43,9 @@ const fetchInputs = (conn: Connection, dispatch: Dispatch<AnyAction>) => {
  * passed into Redux via the UPDATE_API_DATA action.
  */
 const createAPIMiddleware = () => {
-  if (!process.env.NEXT_PUBLIC_ETENGINE_URL) {
+  if (!process.env.NEXT_PUBLIC_MYETM_URL) {
     throw new Error(
-      'Cannot create API middleware without an API URL. Please set NEXT_PUBLIC_ETENGINE_URL.'
+      'Cannot create API middleware without an API URL. Please set NEXT_PUBLIC_MYETM_URL.'
     );
   }
 


### PR DESCRIPTION
I think to select a scenario it is more helpful to go back to MyETM, and in a lot of cases when there are auth issues it is safer to navigate back to MyETM than to go directly to the model - what do you think? I haven't changed the links everywhere, just where I thought it was the most logical.