### PR TITLE
Scope tokens to domains to avoid cookie mismatches on stable versions

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -53,8 +53,7 @@ export const authOptions = {
 
       wellKnown: `${process.env.NEXT_PUBLIC_MYETM_URL}/.well-known/openid-configuration`,
       authorization: {
-        params: { scope: 'openid profile email scenarios:read scenarios:write' },
-        prompt: 'consent'
+        params: { scope: 'openid profile email scenarios:read scenarios:write' }
       },
 
       idToken: true,
@@ -112,6 +111,17 @@ export const authOptions = {
       }
 
       return Promise.resolve(baseUrl);
+    },
+    cookies: {
+      sessionToken: {
+        name: "__Scoped-next-auth.session-token",
+        options: {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          domain: new URL(process.env.NEXTAUTH_URL).host
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
This PR:
- removes the `prompt: consent` tag to allow the upstream action to determine whether a prompt is required for sign in - I think this might mitigate some of the re-prompting to sign in that happens in the collections app, only prompting on first sign in.
- Adds a defined config for the next auth cookies that scopes them to the specific domain they are on (not just the higher level domain). My theory is that because auth tokens were scoped to the domain level, the session was not prompted to refresh.

This token:
```
__Secure-next-auth.session-token
```
was not scoped on the 2025-01 level like the other cookies:
```
__Host-next-auth.csrf-token    host: 2025-01-collections.energytransitionmodel.com  
__Secure-next-auth.callback-url host: 2025-01-collections.energytransitionmodel.com  
```