### PR TITLE
Improve locales for series hide/show in charts

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -281,7 +281,7 @@ const Chart = ({ series, style }: ChartProps) => {
           onClick={onToggleAllSeries}
           className="group mb-2 flex items-center rounded py-2 px-3 text-sm font-medium text-white bg-midnight-500 cursor-pointer transition hover:bg-midnight-600"
           >
-          {allSeriesHidden ? <LocaleMessage id="inputs.all" /> : <LocaleMessage id="inputs.hide" />}
+          {allSeriesHidden ? <LocaleMessage id="series.all" /> : <LocaleMessage id="series.hide" />}
         </button>
     </div>
   );

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -19,7 +19,9 @@
   "inputs.all": "Show all inputs",
   "inputs.collapse": "Collapse all",
   "inputs.expand": "Expand all",
-  "inputs.hide": "Hide all inputs",
+
+  "series.all": "Show all series",
+  "series.hide": "Hide all series",
 
   "scenarioEditor.title": "Edit {year} scenario",
   "scenarioEditor.finish": "Finish editing",

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -19,7 +19,9 @@
   "inputs.all": "Alle sliders tonen",
   "inputs.collapse": "Alles inklappen",
   "inputs.expand": "Alles uitklappen",
-  "inputs.hide": "Verberg alle invoeren",
+
+  "series.all": "Toon alle series",
+  "series.hide": "Verberg alle series",
 
   "scenarioEditor.title": "{year} scenario aanpassen",
   "scenarioEditor.finish": "Gereed",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
The translations for the hide/show series in charts referred to "inputs". This was confusing as it did not concern the inputs. This PR clarifies that.