### PR TITLE
Remove Sentry browser profiling

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -7,15 +7,7 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN && enabledEnvs.includes(process.env.NEXT_
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
     environment: process.env.NEXT_PUBLIC_APP_ENV,
-    integrations: [Sentry.browserProfilingIntegration()],
-
     // Percentage of transactions to capture for tracing
     tracesSampleRate: parseFloat(process.env.NEXT_PUBLIC_SENTRY_TRACES || '0.1'),
-
-    // Percentage of sampled transactions to profile
-    profileSessionSampleRate: parseFloat(process.env.NEXT_PUBLIC_SENTRY_PROFILES || '0.1'),
-
-    // Automatically start/stop profiler based on tracing spans
-    profileLifecycle: 'trace',
   });
 }


### PR DESCRIPTION
#### Context

Sentry browser profiling was enabled but proved mostly unusable. The call tree was dominated by minified framework code even with source maps in place. We're paying for profiling hours with little actionable insight.

#### Implemented changes

- Removed `browserProfilingIntegration` from Sentry init
- Removed `profileSessionSampleRate` and `profileLifecycle` options

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
